### PR TITLE
feat: added database seed for a master user

### DIFF
--- a/ERP/database/seeders/DatabaseSeeder.php
+++ b/ERP/database/seeders/DatabaseSeeder.php
@@ -13,6 +13,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run()
     {
-        // \App\Models\User::factory(10)->create();
+        $this-> call(MasterUserSeeder::class);
     }
 }

--- a/ERP/database/seeders/MasterUserSeeder.php
+++ b/ERP/database/seeders/MasterUserSeeder.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+class MasterUserSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        $masterUser = new User();
+        $masterUser -> first_name = 'IT';
+        $masterUser -> last_name = 'Admin';
+        $masterUser -> email = 'admin@gmail.com';
+        $masterUser -> password = Hash::make('password');
+        $masterUser -> user_type = 0;
+
+        $user = User::where('email', '=', $masterUser->email)->first();
+
+        if($user == null)
+            $masterUser->save();
+
+    }
+}


### PR DESCRIPTION
- If you were to run this application locally, without any DB entries in the `users` table, there would be no way for the user to log in, since there would be no account to authenticate against.
- Therefore, to solve this, a SEEDER is used to create a single entry in the database that can be used to login. See below for details.
---
- Added `MasterUserSeeder` class that adds an IT Department user with the following credentials
**username: admin@gmail.com
password: password**

- In order to run the seed, please run `php artisan db:seed`
![image](https://user-images.githubusercontent.com/31664874/106631626-ecd06e00-654a-11eb-904e-31c6822bec10.png)

### Prerequisites:
- In order to be able to run this command, you need to already have the database tables up (by running `php artisan migrate`
- The `php artisan migrate` command will create all the tables based on the migration files found under `database\migrations`
---
