### PR TITLE
Bugfix(issue 141): fix job seeder

### DIFF
--- a/ERP/app/Models/Job.php
+++ b/ERP/app/Models/Job.php
@@ -15,7 +15,8 @@ class Job extends Model
      * @var array
      */
     protected $fillable = [
-        'status'
+        'status',
+        'quantity'
     ];
 
 

--- a/ERP/database/migrations/2021_02_23_160206_create_jobs_table.php
+++ b/ERP/database/migrations/2021_02_23_160206_create_jobs_table.php
@@ -16,8 +16,9 @@ class CreateJobsTable extends Migration
         Schema::create('jobs', function (Blueprint $table) {
             $table->id();
             $table->timestamps();
+            $table->integer('quantity');
             $table->string('status');
-            $table->foreignId('user_id')->references('id')->on('users');
+            $table->foreignId('user_id')->nullable()->references('id')->on('users');
             $table->foreignId('bike_id')->references('id')->on('bikes');
         });
     }

--- a/ERP/database/seeders/DatabaseSeeder.php
+++ b/ERP/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,6 @@ class DatabaseSeeder extends Seeder
         $this-> call(MasterUserSeeder::class);
         $this-> call(DefaultMachineSeeder::class);
         $this->call(Bike_Parts_Material_Order_Sale_Seeder::class);
-        //$this-> call(DefaultJobSeeder::class);
+        $this-> call(DefaultJobSeeder::class);
     }
 }

--- a/ERP/database/seeders/DefaultJobSeeder.php
+++ b/ERP/database/seeders/DefaultJobSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Bike;
 use App\Models\Job;
 use Illuminate\Database\Seeder;
 
@@ -14,10 +15,17 @@ class DefaultJobSeeder extends Seeder
      */
     public function run()
     {
-        //
-        $defaultJob = new Job();
-        $defaultJob -> status = 'Queued';
+        //Create seed jobs for each bike currently in the database.
+        //Since all seeds are run at the same time, the list of bikes defined in the Bike_parts_Material_Order_Sale_Seeder
+        //will be used for this purpose.
+        $bikes = Bike::all();
 
-        $defaultJob->save();
+        foreach($bikes as $bike) {
+            $defaultJob = new Job();
+            $defaultJob->status = 'Queued';
+            $defaultJob->quantity = rand(1, 25);
+            $defaultJob->bike_id = $bike->id;
+            $defaultJob->save();
+        }
     }
 }

--- a/ERP/resources/views/jobs.blade.php
+++ b/ERP/resources/views/jobs.blade.php
@@ -4,35 +4,44 @@
     <div class="container-fluid my-4">
         <div class="panel panel-primary">
             <div class="panel-heading">
-            <div class="row">
-                <div class="col">
-                <h1 class="panel-title">JOBS</h1>
-                </div>
-                <div class="col">
-                    <div class="float-right">
-                        @include('components.backlog-modal')
+                <div class="row">
+                    <div class="col">
+                        <h1 class="panel-title">JOBS</h1>
+                    </div>
+                    <div class="col">
+                        <div class="float-right">
+                            @include('components.backlog-modal')
+                        </div>
                     </div>
                 </div>
-            </div>
 
                 <p>List of jobs that need to be completed</p>
             </div>
             <div class="panel-body">
                 <div class="row">
                     <div class="col-10" id="jobs">
-                    <!-- Jobs table -->
+                        <!-- Jobs table -->
                         <h3>Jobs</h3>
                         <table class="table table-bordered">
                             <thead>
-                            <th class="sort pointer-cursor" data-sort="jobid">JobID</th>
-                            <th class="sort pointer-cursor" data-sort="status">Date Created</th>
-                            <th class="sort pointer-cursor" data-sort="status">Status</th>
-                            <th>Operations</th>
+                            <tr>
+                                <th class="sort pointer-cursor" data-sort="jobid">JobID</th>
+                                <th class="sort pointer-cursor" data-sort="jobid">Assignee</th>
+                                <th class="sort pointer-cursor" data-sort="jobid">Bicycle Type</th>
+                                <th class="sort pointer-cursor" data-sort="jobid">Quantity</th>
+                                <th class="sort pointer-cursor" data-sort="status">Date Created</th>
+                                <th class="sort pointer-cursor" data-sort="status">Status</th>
+                                <th>Operations</th>
+                            </tr>
                             </thead>
+
                             <tbody class="list">
                             @foreach ($jobs as $job)
                                 <tr>
                                     <td>{{$job->id}}</td>
+                                    <td>{!!($job->user_id)==null ? html_entity_decode("<p class=text-muted><em>NONE</em></p>"): DB::table('users')->where('id',$job->user_id)->value('first_name') !!}</td>
+                                    <td>{{DB::table('bikes')->where('id',$job->bike_id)->value('type')}}</td>
+                                    <td>{{$job->quantity}}</td>
                                     <td>{{$job->created_at}}</td>
                                     <td>{{$job->status}}</td>
                                     <td><a type="button" class="btn btn-primary" href="toggle-job-status/{{$job->id}}">Toggle


### PR DESCRIPTION
- This Pull Request addresses the bug reported in Issue #141 
---
- Fixed job seeder by adding the missing attributes in the seeder as well as making some of the foreign keys nullable (user_id)
  - If the user_id key is null, it means that there is no one assigned to the job YET

- Added a new attribute to Job table that reflects the number of bikes to be produced for a particular job
![image](https://user-images.githubusercontent.com/31664874/111547915-42a25380-8750-11eb-8463-0ca0fbba137b.png)


- Also, since we added the relationships to all tables, I made sure that the UI reflects this change.
  - The UI now displays info pertaining to its relationship with `Bike` and `User`
  - Each job in the jobs table will now display the ASSIGNEE (user) as well as the BIKE associated with the job.
  - Also added the QUANTITY attribute to the jobs table

![image](https://user-images.githubusercontent.com/31664874/111548101-90b75700-8750-11eb-9d44-d0813164f74f.png)

