### PR TITLE
bugfix(issue-166-167-175-176): fixed multiple pending bugs

### DIFF
--- a/ERP/app/Http/Controllers/BikeController.php
+++ b/ERP/app/Http/Controllers/BikeController.php
@@ -209,7 +209,7 @@ class BikeController extends Controller
 
         //Redirect the user to the inventory page
         return redirect('/inventory')
-            ->with('success_msg', 'Bike Deleted'); //Send a temporary success message. This is saved in the session
+            ->with('success_msg', 'Bike Has Been Successfully Deleted'); //Send a temporary success message. This is saved in the session
     }
 
 }

--- a/ERP/app/Http/Controllers/JobController.php
+++ b/ERP/app/Http/Controllers/JobController.php
@@ -2,13 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\Bike;
 use App\Models\Log;
 use App\Models\Order;
 use Illuminate\Http\Request;
 use App\Models\Job;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
-use Illuminate\Validation\Rules\RequiredIf;
 
 class JobController extends Controller
 {
@@ -23,8 +24,9 @@ class JobController extends Controller
 
         $validator = Validator::make($request->all(), [
             'status' => 'required',
-            'quantity' => 'required',
-            'bike_id' => 'required'
+            'order_qty' => 'required',
+            'bike' => 'required',
+            'user' => 'required'
         ]);
 
         //If validation fails user is redirected to inventory
@@ -50,8 +52,9 @@ class JobController extends Controller
         //Otherwise successfully create and store a job
         $newJob= Job::create([
             'status' => $request->status,
-            'quantity' => $request->quantity,
-            'bike_id' => $request->bike_id
+            'quantity' => $request->order_qty,
+            'bike_id' => $request->bike,
+            'user_id' =>$request->user
         ]);
 
         //Log results
@@ -139,6 +142,14 @@ class JobController extends Controller
      */
     public function goToCreateJob(Request $request) {
 
+        //Each job needs an associated bike, therefore the list of all bikes is returned to the view
+        $bikes = Bike::all();
+
+        //Each job has an assignee (manufacturer worker, user_type = 5)
+        $manufacturerWorkers = DB::table('users')
+            ->where('user_type', '=', 5)
+            ->get();
+
         //Get results
         $msg_str = 'Job Creation page accessed';
         Log::create([
@@ -150,7 +161,7 @@ class JobController extends Controller
         ]);
 
         //Redirect user to create-job page
-        return view('create-job');
+        return view('create-job', ['bikes' => $bikes, 'users' => $manufacturerWorkers]);
     }
 
     /**

--- a/ERP/app/Http/Controllers/MaterialController.php
+++ b/ERP/app/Http/Controllers/MaterialController.php
@@ -77,22 +77,41 @@ class MaterialController extends Controller
     */
     public function destroy($id, Request $request) {
 
-        //Take the id parameter and insert it into the following query
-        DB::delete('delete from materials where id = ?',[$id]);
+        //Find all parts associated with the material
+        $partMaterialRelationship = DB::table('material_part')->where('material_id', '=', $id);
 
-        //Log the results of the post request
-        $msg_str = 'Material with ID '. $id . ' successfully deleted';
-        Log::create([
-            'user_id' => Auth::user()->id,
-            'ip_address' => $request ->ip(),
-            'log_type' => 'INFO',
-            'request_type' => 'POST',
-            'message' => $msg_str,
-        ]);
 
-        //Redirect the user to the inventory page
-        return redirect('/inventory')
-            ->with('success_msg', 'Material Deleted'); //Send a temporary success message. This is saved in the session
+        if($partMaterialRelationship->count() == 0) {
+            //Take the id parameter and insert it into the following query
+            DB::delete('delete from materials where id = ?', [$id]);
+
+            //Log the results of the post request
+            $msg_str = 'Material with ID ' . $id . ' successfully deleted';
+            Log::create([
+                'user_id' => Auth::user()->id,
+                'ip_address' => $request->ip(),
+                'log_type' => 'INFO',
+                'request_type' => 'POST',
+                'message' => $msg_str,
+            ]);
+
+            //Redirect the user to the inventory page
+            return redirect('/inventory')
+                ->with('success_msg', 'Material has been Successfully Deleted'); //Send a temporary success message. This is saved in the session
+        } else {
+
+            $msg_str = $msg_str = 'Failed to delete Material with ID ' . $id. ' Due to It Being Used by a Part';
+            Log::create([
+                'user_id' => Auth::user()->id,
+                'ip_address' => $request->ip(),
+                'log_type' => 'ERROR',
+                'request_type' => 'POST',
+                'message' => $msg_str,
+            ]);
+            //Redirect the user to the inventory page with errors
+            return redirect('/inventory')->withErrors(['This Material can not Be Deleted since there is 1 or more Part that is Built Using this Material']);
+
+        }
      }
 
     /**

--- a/ERP/app/Http/Controllers/MaterialController.php
+++ b/ERP/app/Http/Controllers/MaterialController.php
@@ -100,7 +100,7 @@ class MaterialController extends Controller
                 ->with('success_msg', 'Material has been Successfully Deleted'); //Send a temporary success message. This is saved in the session
         } else {
 
-            $msg_str = $msg_str = 'Failed to delete Material with ID ' . $id. ' Due to It Being Used by a Part';
+            $msg_str = $msg_str = 'Failed to delete material with ID ' . $id. ' due to it being used by a part';
             Log::create([
                 'user_id' => Auth::user()->id,
                 'ip_address' => $request->ip(),
@@ -109,7 +109,7 @@ class MaterialController extends Controller
                 'message' => $msg_str,
             ]);
             //Redirect the user to the inventory page with errors
-            return redirect('/inventory')->withErrors(['This Material can not Be Deleted since there is 1 or more Part that is Built Using this Material']);
+            return redirect('/inventory')->withErrors(['This material can not be deleted since there is 1 or more part that is built using this material']);
 
         }
      }

--- a/ERP/app/Http/Controllers/PartController.php
+++ b/ERP/app/Http/Controllers/PartController.php
@@ -101,7 +101,7 @@ class PartController extends Controller
 
 
             //Log the results of the failed post request
-            $msg_str = 'Failed to delete Part with ID ' . $id. ' Due to It Being Used by a Bike';
+            $msg_str = 'Failed to delete part with ID ' . $id. ' due to it being used by a bike';
             Log::create([
                 'user_id' => Auth::user()->id,
                 'ip_address' => $request->ip(),
@@ -110,7 +110,7 @@ class PartController extends Controller
                 'message' => $msg_str,
             ]);
             //Redirect the user to the inventory page with errors
-            return redirect('/inventory')->withErrors(['This Part can not Be Deleted since there is 1 or more Bike that is Built Using this Part']);
+            return redirect('/inventory')->withErrors(['This part can not Be deleted since there is 1 or more bike that is built using this part']);
 
         }
      }

--- a/ERP/app/Models/Job.php
+++ b/ERP/app/Models/Job.php
@@ -17,7 +17,8 @@ class Job extends Model
     protected $fillable = [
         'status',
         'quantity',
-        'bike_id'
+        'bike_id',
+        'user_id'
     ];
 
 

--- a/ERP/database/migrations/2021_02_23_160206_create_jobs_table.php
+++ b/ERP/database/migrations/2021_02_23_160206_create_jobs_table.php
@@ -19,7 +19,7 @@ class CreateJobsTable extends Migration
             $table->integer('quantity');
             $table->string('status');
             $table->foreignId('user_id')->nullable()->references('id')->on('users');
-            $table->foreignId('bike_id')->references('id')->on('bikes');
+            $table->foreignId('bike_id')->references('id')->on('bikes')->onDelete('cascade');
         });
     }
 

--- a/ERP/database/migrations/2021_03_15_131721_material_part.php
+++ b/ERP/database/migrations/2021_03_15_131721_material_part.php
@@ -15,7 +15,7 @@ class MaterialPart extends Migration
     {
         Schema::create('material_part', function (Blueprint $table) {
             $table->foreignId('material_id')->references('id')->on('materials');
-            $table->foreignId('part_id')->references('id')->on('parts');
+            $table->foreignId('part_id')->references('id')->on('parts')->cascadeOnDelete();
         });
     }
 

--- a/ERP/database/migrations/2021_03_15_132046_create_bike_sale_table.php
+++ b/ERP/database/migrations/2021_03_15_132046_create_bike_sale_table.php
@@ -18,9 +18,9 @@ class CreateBikeSaleTable extends Migration
 
             // Defining the columns in the table.
             $table->foreignId('sale_id')->references('id')->on('sales');
-            $table->foreignId('bike_id')->references('id')->on('bikes');
+            $table->foreignId('bike_id')->references('id')->on('bikes')->cascadeOnDelete();
             $table->integer('quantity_sold');
-            
+
         });
     }
 

--- a/ERP/database/migrations/2021_03_15_132046_create_bike_sale_table.php
+++ b/ERP/database/migrations/2021_03_15_132046_create_bike_sale_table.php
@@ -18,7 +18,7 @@ class CreateBikeSaleTable extends Migration
 
             // Defining the columns in the table.
             $table->foreignId('sale_id')->references('id')->on('sales');
-            $table->foreignId('bike_id')->references('id')->on('bikes')->cascadeOnDelete();
+            $table->foreignId('bike_id')->nullable()->references('id')->on('bikes')->nullOnDelete();
             $table->integer('quantity_sold');
 
         });

--- a/ERP/database/migrations/2021_03_15_141027_bike_part.php
+++ b/ERP/database/migrations/2021_03_15_141027_bike_part.php
@@ -14,7 +14,7 @@ class BikePart extends Migration
     public function up()
     {
         Schema::create('bike_part', function (Blueprint $table) {
-            $table->foreignId('bike_id')->references('id')->on('bikes');
+            $table->foreignId('bike_id')->references('id')->on('bikes')->cascadeOnDelete();
             $table->foreignId('part_id')->references('id')->on('parts');
         });
     }

--- a/ERP/database/migrations/2021_03_15_152136_material_order.php
+++ b/ERP/database/migrations/2021_03_15_152136_material_order.php
@@ -15,7 +15,7 @@ class MaterialOrder extends Migration
     {
         Schema::create('material_order', function (Blueprint $table) {
             $table->foreignId('order_id')->references('id')->on('orders');
-            $table->foreignId('material_id')->references('id')->on('materials');
+            $table->foreignId('material_id')->references('id')->on('materials')->cascadeOnDelete();
             $table->integer('order_quantity')->default(1);
         });
     }

--- a/ERP/database/seeders/MasterUserSeeder.php
+++ b/ERP/database/seeders/MasterUserSeeder.php
@@ -27,20 +27,6 @@ class MasterUserSeeder extends Seeder
         if($user == null)
             $masterUser->save();
 
-        $hrUser = new User();
-        $hrUser -> first_name = 'Joe';
-        $hrUser -> last_name = 'Bobberson';
-        $hrUser -> email = 'hr@gmail.com';
-        $hrUser -> password = Hash::make('password');
-        $hrUser -> user_type = 1;
-
-        $floorUser = new User();
-        $floorUser -> first_name = 'Nikkie';
-        $floorUser -> last_name = 'Minaj';
-        $floorUser -> email = 'floor@gmail.com';
-        $floorUser -> password = Hash::make('password');
-        $floorUser -> user_type = 2;
-
         $shippingUser = new User();
         $shippingUser -> first_name = 'Contigo';
         $shippingUser -> last_name = 'Las Vegas';
@@ -76,16 +62,11 @@ class MasterUserSeeder extends Seeder
         $manufacturerWorker3 -> password = Hash::make('password');
         $manufacturerWorker3 -> user_type = 5;
 
-        $user2 = User::where('email', '=', $hrUser->email)->first();
 
-        if($user2 == null)
-            $hrUser->save();
 
-        $user3 = User::where('email', '=', $floorUser->email)->first();
-
-        if($user3 == null)
-            $floorUser->save();
-
+        //The code below verifies that the users we are adding to the database as a seed does not already exist in the database.
+        //If the entry already exists, then it will not be added to the DB as it will throw an error if we do
+        
         $user4 = User::where('email', '=', $shippingUser->email)->first();
 
         if($user4 == null)

--- a/ERP/database/seeders/MasterUserSeeder.php
+++ b/ERP/database/seeders/MasterUserSeeder.php
@@ -16,8 +16,8 @@ class MasterUserSeeder extends Seeder
     public function run()
     {
         $masterUser = new User();
-        $masterUser -> first_name = 'IT';
-        $masterUser -> last_name = 'Admin';
+        $masterUser -> first_name = 'Jimmy';
+        $masterUser -> last_name = 'Neutron';
         $masterUser -> email = 'admin@gmail.com';
         $masterUser -> password = Hash::make('password');
         $masterUser -> user_type = 0;
@@ -28,32 +28,53 @@ class MasterUserSeeder extends Seeder
             $masterUser->save();
 
         $hrUser = new User();
-        $hrUser -> first_name = 'Human';
-        $hrUser -> last_name = 'Resources';
+        $hrUser -> first_name = 'Joe';
+        $hrUser -> last_name = 'Bobberson';
         $hrUser -> email = 'hr@gmail.com';
         $hrUser -> password = Hash::make('password');
         $hrUser -> user_type = 1;
 
         $floorUser = new User();
-        $floorUser -> first_name = 'Floor';
-        $floorUser -> last_name = 'Worker';
+        $floorUser -> first_name = 'Nikkie';
+        $floorUser -> last_name = 'Minaj';
         $floorUser -> email = 'floor@gmail.com';
         $floorUser -> password = Hash::make('password');
         $floorUser -> user_type = 2;
 
         $shippingUser = new User();
-        $shippingUser -> first_name = 'Shipping';
-        $shippingUser -> last_name = 'Department';
+        $shippingUser -> first_name = 'Contigo';
+        $shippingUser -> last_name = 'Las Vegas';
         $shippingUser -> email = 'shipping@gmail.com';
         $shippingUser -> password = Hash::make('password');
         $shippingUser -> user_type = 3;
 
         $inventoryUser = new User();
-        $inventoryUser -> first_name = 'Inventory';
-        $inventoryUser -> last_name = 'Manager';
+        $inventoryUser -> first_name = 'Guy';
+        $inventoryUser -> last_name = 'Fieri';
         $inventoryUser -> email = 'inventory@gmail.com';
         $inventoryUser -> password = Hash::make('password');
         $inventoryUser -> user_type = 4;
+
+        $manufacturerWorker = new User();
+        $manufacturerWorker -> first_name = 'Git';
+        $manufacturerWorker -> last_name = 'Man';
+        $manufacturerWorker -> email = 'gman@gmail.com';
+        $manufacturerWorker -> password = Hash::make('password');
+        $manufacturerWorker -> user_type = 5;
+
+        $manufacturerWorker2 = new User();
+        $manufacturerWorker2 -> first_name = 'Robert';
+        $manufacturerWorker2 -> last_name = 'Kardashian';
+        $manufacturerWorker2 -> email = 'rk@gmail.com';
+        $manufacturerWorker2 -> password = Hash::make('password');
+        $manufacturerWorker2 -> user_type = 5;
+
+        $manufacturerWorker3 = new User();
+        $manufacturerWorker3 -> first_name = 'Lil';
+        $manufacturerWorker3 -> last_name = 'Uzi';
+        $manufacturerWorker3 -> email = 'uzi@gmail.com';
+        $manufacturerWorker3 -> password = Hash::make('password');
+        $manufacturerWorker3 -> user_type = 5;
 
         $user2 = User::where('email', '=', $hrUser->email)->first();
 
@@ -74,6 +95,23 @@ class MasterUserSeeder extends Seeder
 
         if($user5 == null)
             $inventoryUser->save();
+
+
+        $user6 = User::where('email', '=', $manufacturerWorker->email)->first();
+
+        if($user6 == null)
+            $manufacturerWorker->save();
+
+
+        $user7 = User::where('email', '=', $manufacturerWorker2->email)->first();
+
+        if($user7 == null)
+            $manufacturerWorker2->save();
+
+        $user8 = User::where('email', '=', $manufacturerWorker3->email)->first();
+
+        if($user8== null)
+            $manufacturerWorker3->save();
 
     }
 }

--- a/ERP/resources/views/User/create-user.blade.php
+++ b/ERP/resources/views/User/create-user.blade.php
@@ -50,16 +50,8 @@
                 </div>
 
                 <div class="p-2">
-                    <select name="user_type" class="form-control" required>
-                        <option value="">-- SELECT USER TYPE --</option>
-                        <option value="0">IT Department</option>
-                        <option value="1">Human Resources (HR)</option>
-                        <option value="2">Floor Worker</option>
-                        <option value="3">Shipping Department</option>
-                        <option value="4">Inventory</option>
-                        <option value="5">Manufacturer Worker</option>
-                        <option value="6">Accountant</option>
-                    </select>
+                    <!-- If you want to modify the user type dropdown, see the user-type-dropdown blade file -->
+                    @include('components.user-type-dropdown')
                 </div>
 
                 {{csrf_field()}}

--- a/ERP/resources/views/User/create-user.blade.php
+++ b/ERP/resources/views/User/create-user.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 @section('inside-body-tag')
+
+    <!-- Display temporary error message when redirected to this page by controller due to an error-->
     @if(count($errors->all()))
         <div class="alert alert-danger" role="alert">
             <ul>
@@ -10,15 +12,6 @@
         </div>
     @endif
 
-    @if(count($errors->all()))
-        <div class="alert alert-success" role="alert">
-            <ul>
-                @foreach($success->all() as $error)
-                    <li>{{$error}}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
     <form action={{route('create.user')}} method="POST">
         <div class="d-flex justify-content-center mt-5">
             <div class="d-flex flex-column border rounded shadow p-2">

--- a/ERP/resources/views/User/create-user.blade.php
+++ b/ERP/resources/views/User/create-user.blade.php
@@ -9,6 +9,16 @@
             </ul>
         </div>
     @endif
+
+    @if(count($errors->all()))
+        <div class="alert alert-success" role="alert">
+            <ul>
+                @foreach($success->all() as $error)
+                    <li>{{$error}}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
     <form action={{route('create.user')}} method="POST">
         <div class="d-flex justify-content-center mt-5">
             <div class="d-flex flex-column border rounded shadow p-2">

--- a/ERP/resources/views/User/user-management.blade.php
+++ b/ERP/resources/views/User/user-management.blade.php
@@ -13,9 +13,87 @@
 
     @if(Session::has('success_msg'))
         <div class="alert alert-success" role="alert">
-           {{ Session::get('success_msg')}}
+            {{ Session::get('success_msg')}}
         </div>
     @endif
+
+
+    <!-- script that will display the proper user type definition based on the
+user-type-dropdown component. Therefore, the component is used as the single source of truth
+for the list of user types-->
+    <script type="text/javascript">
+        function displayProperUserType(u_type) {
+
+            var dropDown = document.getElementById('user_type');
+            for (var i=0; i<dropDown.length; i++){
+
+                if(dropDown.options[i].value !== "" && dropDown.options[i].value == u_type) {
+                    return dropDown.options[i].text
+                }
+            }
+        }
+    </script>
+
+    <!-- Modal -->
+    <!-- The location of the modal does not matter for it to function.
+     However, in this specific page, it is placed BEFORE the trigger because of the
+     javascript function displayProperUserType. The function needs to capture the dropdown form element
+     BEFORE the user management table is loaded (since the function is called in within the table elements).
+      If the modal was placed after the function call, then the dropDown variable would be null (since the element
+      does not exist on the page yet)-->
+    @foreach($users as $user)
+        <div class="modal fade" id="editUser{{$user->id}}" tabindex="-1">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="exampleModalLabel">EDIT USER:  {{$user->first_name}} {{$user->last_name}}</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                    <div class="modal-body">
+                        <form action={{route('update.user')}} method="POST">
+
+                            <div class="d-flex flex-column p-2">
+                                <div class="d-flex flex-row p-2">
+                                    <div class="py-2">
+                                        <label for="first_name" class="form-label">First Name</label>
+                                        <input type="text" name="first_name" class="form-control" id="first_name" value="{{$user->first_name}}" required>
+                                    </div>
+                                    <div class="p-2">
+                                        <label for="last_name" class="form-label">Last Name</label>
+                                        <input type="text" name="last_name" class="form-control" id="last_name" value="{{$user->last_name}}" required>
+                                    </div>
+
+                                </div>
+                                <div class="p-2">
+                                    <label for="email" class="form-label">Email address</label>
+                                    <input type="email" name="email" class="form-control" id="email" value="{{$user->email}}" required>
+                                </div>
+
+                                <div class="p-2">
+                                    <label for="user_type" class="form-label">User type</label>
+                                    <!-- If you want to modify the user type dropdown, see the user-type-dropdown blade file -->
+                                    @include('components.user-type-dropdown')
+                                </div>
+
+                                <!--CSFR token for security -->
+                            {{csrf_field()}}
+
+                            <!--Hidden field to pass user ID to server-side -->
+                                <input name="user_id" type="hidden" value="{{$user->id}}">
+                            </div>
+
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                                <button type="submit" class="btn btn-primary">Save changes</button>
+                            </div>
+
+                        </form>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    @endforeach
 
         <form action="{{route('create.user')}}">
             <div class="d-grid gap-2 col-3 mx-auto mt-5">
@@ -43,30 +121,7 @@
                     <td>{{$user->last_name}}</td>
                     <td>{{$user->email}}</td>
                     <td>
-                        @switch($user->user_type)
-                            @case(0)
-                            IT Department
-                            @break
-
-                            @case(1)
-                            Human Resources
-                            @break
-
-                            @case(2)
-                            Floor Worker
-                            @break
-
-                            @case(3)
-                            Shipping Department
-                            @break
-
-                            @case(4)
-                            Inventory
-                            @break
-
-                            @default
-                            Undefined User Type
-                        @endswitch
+                        <script>document.write(displayProperUserType({{$user->user_type}}))</script>
                     </td>
                     <td>{{$user->created_at}}</td>
                     <td>{{$user->updated_at}}</td>
@@ -78,63 +133,7 @@
         </table>
     </div>
 
-    <!-- Modal -->
-        @foreach($users as $user)
-    <div class="modal fade" id="editUser{{$user->id}}" tabindex="-1">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title" id="exampleModalLabel">EDIT USER:  {{$user->first_name}} {{$user->last_name}}</h5>
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                </div>
-                <div class="modal-body">
-                    <form action={{route('update.user')}} method="POST">
 
-                            <div class="d-flex flex-column p-2">
-                                <div class="d-flex flex-row p-2">
-                                    <div class="py-2">
-                                        <label for="first_name" class="form-label">First Name</label>
-                                        <input type="text" name="first_name" class="form-control" id="first_name" value="{{$user->first_name}}" required>
-                                    </div>
-                                    <div class="p-2">
-                                        <label for="last_name" class="form-label">Last Name</label>
-                                        <input type="text" name="last_name" class="form-control" id="last_name" value="{{$user->last_name}}" required>
-                                    </div>
 
-                                </div>
-                                <div class="p-2">
-                                    <label for="email" class="form-label">Email address</label>
-                                    <input type="email" name="email" class="form-control" id="email" value="{{$user->email}}" required>
-                                </div>
 
-                                <div class="p-2">
-                                    <label for="user_type" class="form-label">User type</label>
-                                    <select id="user_type" name="user_type" class="form-control" required>
-                                        <option value="">-- SELECT USER TYPE --</option>
-                                        <option value="0" @if($user->user_type ==0) selected @endif>IT Department</option>
-                                        <option value="1" @if($user->user_type ==1) selected @endif>Human Resources (HR)</option>
-                                        <option value="2" @if($user->user_type ==2) selected @endif>Floor Worker</option>
-                                        <option value="3" @if($user->user_type ==3) selected @endif>Shipping Department</option>
-                                    </select>
-                                </div>
-
-                                <!--CSFR token for security -->
-                                {{csrf_field()}}
-
-                                 <!--Hidden field to pass user ID to server-side -->
-                                <input name="user_id" type="hidden" value="{{$user->id}}">
-                            </div>
-
-                        <div class="modal-footer">
-                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                            <button type="submit" class="btn btn-primary">Save changes</button>
-                        </div>
-
-                    </form>
-                </div>
-
-            </div>
-        </div>
-    </div>
-        @endforeach
 @endsection

--- a/ERP/resources/views/components/user-type-dropdown.blade.php
+++ b/ERP/resources/views/components/user-type-dropdown.blade.php
@@ -1,0 +1,11 @@
+
+<select id="user_type" name="user_type" class="form-control" required>
+    <option value="">-- SELECT USER TYPE --</option>
+    <option value="0" @if(isset($user) && $user->user_type ==0) selected @endif>IT Department</option>
+    <option value="1" @if(isset($user) && $user->user_type ==1) selected @endif>Human Resources (HR)</option>
+    <option value="2" @if(isset($user) && $user->user_type ==2) selected @endif>Floor Worker</option>
+    <option value="3" @if(isset($user) && $user->user_type ==3) selected @endif>Shipping Department</option>
+    <option value="4" @if(isset($user) && $user->user_type ==4) selected @endif>Inventory</option>
+    <option value="5" @if(isset($user) && $user->user_type ==5) selected @endif>Manufacturer Worker</option>
+    <option value="6" @if(isset($user) && $user->user_type ==6) selected @endif>Accountant</option>
+</select>

--- a/ERP/resources/views/components/user-type-dropdown.blade.php
+++ b/ERP/resources/views/components/user-type-dropdown.blade.php
@@ -2,8 +2,6 @@
 <select id="user_type" name="user_type" class="form-control" required>
     <option value="">-- SELECT USER TYPE --</option>
     <option value="0" @if(isset($user) && $user->user_type ==0) selected @endif>IT Department</option>
-    <option value="1" @if(isset($user) && $user->user_type ==1) selected @endif>Human Resources (HR)</option>
-    <option value="2" @if(isset($user) && $user->user_type ==2) selected @endif>Floor Worker</option>
     <option value="3" @if(isset($user) && $user->user_type ==3) selected @endif>Shipping Department</option>
     <option value="4" @if(isset($user) && $user->user_type ==4) selected @endif>Inventory</option>
     <option value="5" @if(isset($user) && $user->user_type ==5) selected @endif>Manufacturer Worker</option>

--- a/ERP/resources/views/create-job.blade.php
+++ b/ERP/resources/views/create-job.blade.php
@@ -13,11 +13,39 @@
         <div class="d-flex justify-content-center mt-5">
             <div class="d-flex flex-column border rounded shadow p-2">
                 <div class="p-2">
-                    <select name="status" class="form-select" required>
-                        <option value="">select job status</option>
-                        <option value="Queued">Queued</option>
-                        <option value="Completed">Completed</option>
+                    <label for="user" class="form-label">Assign Job To</label>
+                    <select id="user" name="user" class="form-control py-1" required>
+                        <option value=""> -- SELECT ASSIGNEE --</option>
+                        @foreach($users as $user)
+                            <option value={{$user->id}}> {{$user->first_name. " ". $user->last_name}} </option>
+                        @endforeach
                     </select>
+                    <hr>
+                    <div class="d-flex flex-row py-2">
+                        <div class="pr-2">
+                            <label for="bike" class="form-label">Bike to Produce</label>
+                            <select id="bike" name="bike" class="form-control py-1" required>
+                                <option value=""> -- SELECT BIKE --</option>
+                                @foreach($bikes as $bike)
+                                    <option value={{$bike->id}}> {{$bike->type}} </option>
+                                @endforeach
+                            </select>
+                        </div>
+
+                        <div class="pl-2">
+                            <label for="order_qty" class="form-label">Quantity to Produce</label>
+                            <input type="number" name="order_qty" class="form-control" id="order_qty" required>
+                        </div>
+
+                    </div>
+                    <div class="py-2">
+                        <label for="status" class="form-label">Job Status</label>
+                        <select id="status" name="status" class="form-control  py-1" required>
+                            <option value="Queued" selected>Queued</option>
+                            <option value="Queued">In Progress</option>
+                            <option value="Completed">Completed</option>
+                        </select>
+                    </div>
                 </div>
 
                 {{csrf_field()}}
@@ -30,4 +58,4 @@
 
     </form>
 
-@endsection     
+@endsection

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -276,13 +276,13 @@
                                     @endif
                                     <td>
                                         <a class="btn btn-primary" data-placement="top"
-                                           data-target="#modal-edit-material{{ $part->id }}" data-toggle="modal"
+                                           data-target="#modal-edit-material{{ $material->id }}" data-toggle="modal"
                                            id="modal-edit-material">Edit</a>
                                         <a type="button" class="btn btn-danger" href="deleteMaterial/{{$material->id}}">Delete</button>
                                     </td>
                                 </tr>
 
-                                <div class="modal fade" id="modal-edit-material{{ $part->id }}" tabindex="-1"
+                                <div class="modal fade" id="modal-edit-material{{ $material->id }}" tabindex="-1"
                                      role="dialog" aria-labelledby="edit_material_modal_lable" aria-hidden="true">
                                     <div class="modal-dialog" role="document">
                                         <div class="modal-content">

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -1,5 +1,21 @@
 @extends('layouts.master')
 @section('inside-body-tag')
+    @if(count($errors->all()))
+        <div class="alert alert-danger" role="alert">
+            <ul>
+                @foreach($errors->all() as $error)
+                    <li>{{$error}}</li>
+                @endforeach
+            </ul>
+        </div>
+    @endif
+
+    @if(Session::has('success_msg'))
+        <div class="alert alert-success" role="alert">
+            {{ Session::get('success_msg')}}
+        </div>
+    @endif
+
     <!-- Container for the whole page -->
     <div class="container-fluid my-4">
         <div class="panel panel-primary"> <!-- Panel for the buttons -->

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -1,5 +1,7 @@
 @extends('layouts.master')
 @section('inside-body-tag')
+
+    <!-- Display temporary error message when redirected to this page by controller due to an error-->
     @if(count($errors->all()))
         <div class="alert alert-danger" role="alert">
             <ul>
@@ -9,7 +11,7 @@
             </ul>
         </div>
     @endif
-
+    <!-- Display temporary success message when successfully deleting a part, material or bike-->
     @if(Session::has('success_msg'))
         <div class="alert alert-success" role="alert">
             {{ Session::get('success_msg')}}

--- a/ERP/resources/views/jobs.blade.php
+++ b/ERP/resources/views/jobs.blade.php
@@ -39,7 +39,7 @@
                             @foreach ($jobs as $job)
                                 <tr>
                                     <td>{{$job->id}}</td>
-                                    <td>{!!($job->user_id)==null ? html_entity_decode("<p class=text-muted><em>NONE</em></p>"): DB::table('users')->where('id',$job->user_id)->value('first_name') !!}</td>
+                                    <td>{!!($job->user_id)==null ? html_entity_decode("<p class=text-muted><em>NONE</em></p>"): DB::table('users')->where('id',$job->user_id)->value('first_name'). " ". DB::table('users')->where('id',$job->user_id)->value('last_name') !!}</td>
                                     <td>{{DB::table('bikes')->where('id',$job->bike_id)->value('type')}}</td>
                                     <td>{{$job->quantity}}</td>
                                     <td>{{$job->created_at}}</td>


### PR DESCRIPTION
# Issue #166 Fix
- Fixed issue that would cause the app to crash when deleting a bike, part or material
  - The issue was caused by the addition of foreign keys that needed to be taken into consideration when performing deletes
- Issue was resolved by cascading some of the deletes, nulling them or *preventing* some deletes if they would affect other tables inadvertently.
  - For example, deleting a bike will delete the associated job and **null** the `bike_id` from the `bike_sale` table.
  - Deleting a part or material, however, will cause an error for the part IF the part is used by an existing bike and for the material IF the material is being used by a current part.
 
 @CeliaCaii This means you will need to save some of the bike attributes in the `bike_sale` pivot table in order to make sure you can still access some of the bike information IF the bike gets deleted. If the bike is deleted, you can even add that as a note in the sale entry by checking for a null value of `bike_id`
![image](https://user-images.githubusercontent.com/31664874/113452355-ceafae80-93d1-11eb-8256-140c5ef6fa88.png)

- _Example of deleting a part that is being used by a bike_
![image](https://user-images.githubusercontent.com/31664874/113452589-48e03300-93d2-11eb-868c-7e04030aee2d.png)
---
---
# Issue #167 Fix
- Fixed issue that would prevent a user from creating a job. Creating a job would not do anything and would redirect the user to the home page
- The reason for the issue is that a `Job` entity requires 2 foreign keys: `bike_id` and `user_id`.
  - Issue was resolved by making sure the controller adds these 2 parameters to the job creation.
  - This entailed modifying the form used to create a job

- _New Job Creation Form_
![image](https://user-images.githubusercontent.com/31664874/113452828-d91e7800-93d2-11eb-844f-13fd9a10120c.png)
---
---
# Issue #175 Fix
- The issue was caused by a wrong variable name. The parts variable name was used in the modal used to edit materials.
- Issue resolved by correcting it to the correct variable name
![image](https://user-images.githubusercontent.com/31664874/113452946-0ec36100-93d3-11eb-94c8-f51121a197e3.png)
---
---
# Issue #176 Fix
- Issue was that the user types were different for the user management page and create a user page.
- This is due to the fact that whenever we have a new user type, we need to update it in multiple locations
- The solution is to have a single source of truth for all the user types.
  - This was accomplished by creating a single SHARED component for the dropdown that defines each user
  - The component is used in the `create user` and `edit user` pages by using Laravel's `@include` tag
  - Therefore, updating the component updates it everywhere
  

- _The Shared Component_
![image](https://user-images.githubusercontent.com/31664874/113453386-dec88d80-93d3-11eb-895c-4d04162a6101.png)

- _Using the Component_
![image](https://user-images.githubusercontent.com/31664874/113453471-06b7f100-93d4-11eb-8fcf-2cc03366d84c.png)


- In order to actually list the user types in the user management page, a javascript function was used to loop through the dropdown elements of the shared component and associate the `user_type` integer to the user type string. Previously, we had a switch statement that had to also be updated when a new user was added.

- _Before VS After_
![image](https://user-images.githubusercontent.com/31664874/113453712-952c7280-93d4-11eb-92b1-b73b4a07dc4d.png)

- _The function that uses the shared component to list user types_
![image](https://user-images.githubusercontent.com/31664874/113453744-a7a6ac00-93d4-11eb-9965-0ac0008f7a39.png)


- _Example of issues caused by not having a single source of truth for each user types_
![image](https://user-images.githubusercontent.com/31664874/113453244-9315e400-93d3-11eb-93ee-c4d0015aa8aa.png)

**_See the GitHub Issue #176  for more screenshot of issues encountered by this bug_**

