### PR TITLE
feat(issue-193): pulled info from DB to populate assembly page

### DIFF
--- a/ERP/app/Http/Controllers/AssemblyController.php
+++ b/ERP/app/Http/Controllers/AssemblyController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Bike;
+use App\Models\Part;
+use Illuminate\Support\Facades\DB;
+
+/**
+ *  Takes care of the logics in the accountant view.
+ */
+class AssemblyController extends Controller
+{
+    // Redirects to the accountant view.
+    public function goToAssemblyView()
+    {
+        $bikes = Bike::all();
+        $parts = Part::all();
+
+        $materials = DB::table('material_part')
+                        ->join('materials', 'material_part.material_id', '=', 'materials.id')
+                        ->get();
+
+        return view('assembly', ['bikes' => $bikes, 'parts' => $parts, 'materials' => $materials]);
+    }
+}

--- a/ERP/app/Http/Controllers/AssemblyController.php
+++ b/ERP/app/Http/Controllers/AssemblyController.php
@@ -8,11 +8,11 @@ use App\Models\Part;
 use Illuminate\Support\Facades\DB;
 
 /**
- *  Takes care of the logics in the accountant view.
+ *  Takes care of the logics in the assembly view.
  */
 class AssemblyController extends Controller
 {
-    // Redirects to the accountant view.
+    // Redirects to the assembly view.
     public function goToAssemblyView()
     {
         $bikes = Bike::all();

--- a/ERP/resources/views/assembly.blade.php
+++ b/ERP/resources/views/assembly.blade.php
@@ -4,10 +4,9 @@
 <div class="container-fluid">
     <div class="panel panel-primary">
         <div class="panel-heading">
+            <br/>
             <h1 class="panel-title">ASSEMBLY</h1>
-            <!--TO BE REMOVED-->
-            <p>TO BE REMOVED -- this page is to know what bicycle needs what part + what parts need what materials</p>
-            <p>table content is irrelevant, but they are there to show what itd look when all is said and done</p>
+            <br/>
         </div>
         <div class="panel-body">
 
@@ -19,13 +18,86 @@
 
                     <table class="table table-bordered">
                         <thead>
-                            <th class="sort pointer-cursor" data-sort="type">PartID</th>
-                            <th class="sort pointer-cursor" data-sort="color">Part Name</th>
-                            <th class="sort pointer-cursor" data-sort="quantity">Required Materials</th>
-                            <th>Quantity Needed</th>
+                            <th scope="col">BikeId</th>
+                            <th scope="col">Fork</th>
+                            <th scope="col">Seatpost</th>
+                            <th scope="col">Headset</th>
+                            <th scope="col">Crankset</th>
+                            <th scope="col">Pedals</th>
+                            <th scope="col">Handlebar</th>
+                            <th scope="col">Stem</th>
+                            <th scope="col">Saddle</th>
+                            <th scope="col">Brakes</th>
+                            <th scope="col">Shock</th>
+                            <th scope="col">Rim</th>
+                            <th scope="col">Tire</th>
                         </thead>
                         <tbody class="list">
-
+                            @foreach($bikes as $bike)
+                                <tr>
+                                    <td>{{$bike->id}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Fork')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Seatpost')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Headset')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Crankset')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Pedals')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Handlebar')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Stem')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Saddle')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Brakes')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Shock')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Rim')
+                                                        ->value('part_name')}}</td>
+                                    <td>{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Tire')
+                                                        ->value('part_name')}}</td>                    
+                                </tr>
+                            @endforeach
                         </tbody>
                     </table>
                 </div>
@@ -38,12 +110,26 @@
                     <h3>Parts Requirements</h3>
                     <table class="table table-bordered">
                         <thead>
-                            <th class="sort pointer-cursor" data-sort="type">MaterialID</th>
-                            <th class="sort pointer-cursor" data-sort="color">Material Name</th>
-                            <th>Quantity Required</th>
+                            <th scope="col">PartID</th>
+                            <th scope="col">Part Name</th>
+                            <th scope="col">Materials</th>
                         </thead>
                         <tbody class="list">
-
+                            @foreach($parts as $part)
+                                <tr>
+                                    <td>{{$part->id}}</td>
+                                    <td>{{$part->part_name}}</td>
+                                    <td>
+                                        <ul>
+                                        @foreach($materials as $material)
+                                            @if($material->part_id == $part->id)
+                                               <li>{{$material->material_name}}</li>
+                                            @endif
+                                        @endforeach
+                                        </ul>
+                                    </td>
+                                </tr>
+                            @endforeach
                         </tbody>
                     </table> 
                 </div>

--- a/ERP/routes/web.php
+++ b/ERP/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\MaterialController;
 use App\Http\Controllers\ShippingController;
 use App\Http\Controllers\JobController;
 use App\Http\Controllers\AccountantController;
+use App\Http\Controllers\AssemblyController;
 use App\Http\Controllers\SaleController;
 use App\Http\Controllers\MachineController;
 use Illuminate\Support\Facades\Route;
@@ -25,9 +26,7 @@ use App\Http\Controllers\DynamicPDFController;
 |
 */
 
-Route::get('/assembly', function () {
-    return view('assembly');
-})
+Route::get('/assembly', [AssemblyController::class, 'goToAssemblyView'])
     ->middleware('auth')
     ->name("assembly");
 


### PR DESCRIPTION
When logging in as a manufacturer worker, you can now access the Assembly page with appropriately filled information.

- The list of parts is listed for every bike:

![Screenshot 2021-04-06 041800](https://user-images.githubusercontent.com/47061375/113681023-84f3ec00-968f-11eb-8006-8cb177678899.png)

- The list of materials is listed for every part:

![Screenshot 2021-04-06 041818](https://user-images.githubusercontent.com/47061375/113681061-8de4bd80-968f-11eb-8cd3-510605b42a0b.png)

**NOTE: You will have issues if you plan on trying to test on this branch. You require the modified seeders that will come with the merge of branch feat/issue-188/display-bike-parts-in-inventory-page/mlee97.