### PR TITLE
feat(issue-188): modified inventory page to accommodate the parts that constitute a bicycle

### DIFF
--- a/ERP/app/Http/Controllers/BikeController.php
+++ b/ERP/app/Http/Controllers/BikeController.php
@@ -36,6 +36,19 @@ class BikeController extends Controller
             'finish' => 'required|string|max:255',
             'grade' => 'required|string|max:255',
             'quantity_in_stock' => 'required|integer',
+
+            'fork' => 'required|integer',
+            'seatpost' => 'required|integer',
+            'headset' => 'required|integer',
+            'cranks' => 'required|integer',
+            'pedals' => 'required|integer',
+            'handlebar' => 'required|integer',
+            'stem' => 'required|integer',
+            'saddle' => 'required|integer',
+            'brakes' => 'required|integer',
+            'shock' => 'required|integer',
+            'rim' => 'required|integer',
+            'tire' => 'required|integer'
         ]);
 
         //If the validation fails, log an error message.
@@ -58,7 +71,7 @@ class BikeController extends Controller
         }
 
         //Create a new bike and associate each input with its appropriate field in the Bike model.
-        $newBike = Bike::create([
+        $bike = Bike::create([
             'type' => $request->type,
             'size' => $request->size,
             'color' => $request->color,
@@ -68,7 +81,32 @@ class BikeController extends Controller
             'quantity_in_stock' => $request->quantity_in_stock,
         ]);
 
-        $msg_str = 'New bicycle with ID ' . $newBike->id . ' successfully created';
+        $fork = Part::find($request->fork);
+        $bike->parts()->save($fork);
+        $seatpost = Part::find($request->seatpost);
+        $bike->parts()->save($seatpost);
+        $headset = Part::find($request->headset);
+        $bike->parts()->save($headset);
+        $cranks = Part::find($request->cranks);
+        $bike->parts()->save($cranks);
+        $pedals = Part::find($request->pedals);
+        $bike->parts()->save($pedals);
+        $handlebar = Part::find($request->handlebar);
+        $bike->parts()->save($handlebar);
+        $stem = Part::find($request->stem);
+        $bike->parts()->save($stem);
+        $saddle = Part::find($request->saddle);
+        $bike->parts()->save($saddle);
+        $brakes = Part::find($request->brakes);
+        $bike->parts()->save($brakes);
+        $shock = Part::find($request->shock);
+        $bike->parts()->save($shock);
+        $rim = Part::find($request->rim);
+        $bike->parts()->save($rim);
+        $tire = Part::find($request->tire);
+        $bike->parts()->save($tire);
+
+        $msg_str = 'New bicycle with ID ' . $bike->id . ' successfully created';
 
         //Log the results of the create operation.
         Log::create([
@@ -102,6 +140,19 @@ class BikeController extends Controller
             'finish' => 'required|string|max:255',
             'grade' => 'required|string|max:255',
             'quantity_in_stock' => 'required|integer',
+
+            'fork' => 'required|integer',
+            'seatpost' => 'required|integer',
+            'headset' => 'required|integer',
+            'cranks' => 'required|integer',
+            'pedals' => 'required|integer',
+            'handlebar' => 'required|integer',
+            'stem' => 'required|integer',
+            'saddle' => 'required|integer',
+            'brakes' => 'required|integer',
+            'shock' => 'required|integer',
+            'rim' => 'required|integer',
+            'tire' => 'required|integer'
         ]);
 
         //If the validation fails, log an error message.
@@ -137,6 +188,7 @@ class BikeController extends Controller
 
         //Log the results of the edit operation.
         $msg_str = 'Bicycle with ID ' . $bike->id . ' updated successfully';
+
         Log::create([
             'user_id' => Auth::user()->id,
             'ip_address' => $request->ip(),

--- a/ERP/app/Models/Part.php
+++ b/ERP/app/Models/Part.php
@@ -16,7 +16,8 @@ class Part extends Model
      */
     protected $fillable = [
         'part_name',
-        'part_quantity_in_stock'
+        'part_quantity_in_stock',
+        'category'
     ];
 
     //relates Parts to materials

--- a/ERP/database/migrations/2021_02_23_115333_create_parts_table.php
+++ b/ERP/database/migrations/2021_02_23_115333_create_parts_table.php
@@ -17,6 +17,7 @@ class CreatePartsTable extends Migration
             $table->id();
             $table->timestamps();
             $table->string('part_name');
+            $table->string('category');
             $table->integer('part_quantity_in_stock');
         });
     }

--- a/ERP/database/seeders/Bike_Parts_Material_Order_Sale_Seeder.php
+++ b/ERP/database/seeders/Bike_Parts_Material_Order_Sale_Seeder.php
@@ -113,6 +113,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $carbon_fiber_fork = new Part();
         $carbon_fiber_fork->part_name = 'Carbon Fiber Fork';
         $carbon_fiber_fork->part_quantity_in_stock = '1';
+        $carbon_fiber_fork->category = 'Fork';
         $partFromDB = Part::where('part_name', '=', $carbon_fiber_fork->part_name)->first();
         if ($partFromDB == null)
             $carbon_fiber_fork->save();
@@ -122,6 +123,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $titanium_fork = new Part();
         $titanium_fork->part_name = 'Titanium Fork';
         $titanium_fork->part_quantity_in_stock = '1';
+        $titanium_fork->category = 'Fork';
         $partFromDB = Part::where('part_name', '=', $titanium_fork->part_name)->first();
         if ($partFromDB == null)
             $titanium_fork->save();
@@ -131,6 +133,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $magnesium_fork = new Part();
         $magnesium_fork->part_name = 'Magnesium Fork';
         $magnesium_fork->part_quantity_in_stock = '1';
+        $magnesium_fork->category = 'Fork';
         $partFromDB = Part::where('part_name', '=', $magnesium_fork->part_name)->first();
         if ($partFromDB == null)
             $magnesium_fork->save();
@@ -139,6 +142,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
 
         $threaded_headset = new Part();
         $threaded_headset->part_name = 'Threaded Headset';
+        $threaded_headset->category = 'Headset';
         $threaded_headset->part_quantity_in_stock = '1';
         $partFromDB = Part::where('part_name', '=', $threaded_headset->part_name)->first();
         if ($partFromDB == null)
@@ -149,6 +153,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
 
         $seatpost = new Part();
         $seatpost->part_name = 'Seatpost';
+        $seatpost->category = 'Seatpost';
         $seatpost->part_quantity_in_stock = '1';
         $partFromDB = Part::where('part_name', '=', $seatpost->part_name)->first();
         if ($partFromDB == null)
@@ -158,6 +163,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $threadless_headset = new Part();
         $threadless_headset->part_name = 'Threadless Headset';
         $threadless_headset->part_quantity_in_stock = '1';
+        $threadless_headset->category = 'Headset';
         $partFromDB = Part::where('part_name', '=', $threadless_headset->part_name)->first();
         if ($partFromDB == null)
             $threadless_headset->save();
@@ -169,6 +175,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $aluminum_crankset = new Part();
         $aluminum_crankset->part_name = 'Aluminum Crankset';
         $aluminum_crankset->part_quantity_in_stock = '1';
+        $aluminum_crankset->category = 'Crankset';
         $partFromDB = Part::where('part_name', '=', $aluminum_crankset->part_name)->first();
         if ($partFromDB == null)
             $aluminum_crankset->save();
@@ -178,6 +185,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $titanium_crankset = new Part();
         $titanium_crankset->part_name = 'Titanium Crankset';
         $titanium_crankset->part_quantity_in_stock = '1';
+        $titanium_crankset->category = 'Crankset';
         $partFromDB = Part::where('part_name', '=', $titanium_crankset->part_name)->first();
         if ($partFromDB == null)
             $titanium_crankset->save();
@@ -187,6 +195,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $plastic_pedals = new Part();
         $plastic_pedals->part_name = 'Plastic Pedals (pair)';
         $plastic_pedals->part_quantity_in_stock = '1';
+        $plastic_pedals->category = 'Pedals';
         $partFromDB = Part::where('part_name', '=', $plastic_pedals->part_name)->first();
         if ($partFromDB == null)
             $plastic_pedals->save();
@@ -195,14 +204,16 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $metal_pedals = new Part();
         $metal_pedals->part_name = 'Metal Pedals (pair)';
         $metal_pedals->part_quantity_in_stock = '1';
+        $metal_pedals->category = 'Pedals';
         $partFromDB = Part::where('part_name', '=', $metal_pedals->part_name)->first();
         if ($partFromDB == null)
             $metal_pedals->save();
         $metal_pedals->materials()->save($stainless_steel);
-
+        
         $standard_handlebar = new Part();
         $standard_handlebar->part_name = 'Standard Handlebar';
         $standard_handlebar->part_quantity_in_stock = '1';
+        $standard_handlebar->category = 'Handlebar';
         $partFromDB = Part::where('part_name', '=', $standard_handlebar->part_name)->first();
         if ($partFromDB == null)
             $standard_handlebar->save();
@@ -212,6 +223,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $stem = new Part();
         $stem->part_name = 'Stem';
         $stem->part_quantity_in_stock = '1';
+        $stem->category = 'Stem';
         $partFromDB = Part::where('part_name', '=', $stem->part_name)->first();
         if ($partFromDB == null)
             $stem->save();
@@ -220,6 +232,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $plastic_saddle = new Part();
         $plastic_saddle->part_name = 'Plastic Saddle';
         $plastic_saddle->part_quantity_in_stock = '1';
+        $plastic_saddle->category = 'Saddle';
         $partFromDB = Part::where('part_name', '=', $plastic_saddle->part_name)->first();
         if ($partFromDB == null)
             $plastic_saddle->save();
@@ -230,6 +243,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $carbon_fiber_saddle = new Part();
         $carbon_fiber_saddle->part_name = 'Carbon Fiber Saddle';
         $carbon_fiber_saddle->part_quantity_in_stock = '1';
+        $carbon_fiber_saddle->category = 'Saddle';
         $partFromDB = Part::where('part_name', '=', $carbon_fiber_saddle->part_name)->first();
         if ($partFromDB == null)
             $carbon_fiber_saddle->save();
@@ -240,6 +254,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $rim_brake_assembly = new Part();
         $rim_brake_assembly->part_name = 'Rim Brake Assembly';
         $rim_brake_assembly->part_quantity_in_stock = '1';
+        $rim_brake_assembly->category = 'Brakes';
         $partFromDB = Part::where('part_name', '=', $rim_brake_assembly->part_name)->first();
         if ($partFromDB == null)
             $rim_brake_assembly->save();
@@ -250,6 +265,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $disk_brake_assembly = new Part();
         $disk_brake_assembly->part_name = 'Disk Brake Assembly';
         $disk_brake_assembly->part_quantity_in_stock = '1';
+        $disk_brake_assembly->category = 'Brakes';
         $partFromDB = Part::where('part_name', '=', $disk_brake_assembly->part_name)->first();
         if ($partFromDB == null)
             $disk_brake_assembly->save();
@@ -261,6 +277,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $shock = new Part();
         $shock->part_name = 'Shock';
         $shock->part_quantity_in_stock = '1';
+        $shock->category = 'Shock';
         $partFromDB = Part::where('part_name', '=', $shock->part_name)->first();
         if ($partFromDB == null)
             $shock->save();
@@ -270,6 +287,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $rim = new Part();
         $rim->part_name = 'Rim';
         $rim->part_quantity_in_stock = '1';
+        $rim->category = 'Rim';
         $partFromDB = Part::where('part_name', '=', $rim->part_name)->first();
         if ($partFromDB == null)
             $rim->save();
@@ -279,6 +297,7 @@ class Bike_Parts_Material_Order_Sale_Seeder extends Seeder
         $tire = new Part();
         $tire->part_name = 'Tire';
         $tire->part_quantity_in_stock = '1';
+        $tire->category = 'Tire';
         $partFromDB = Part::where('part_name', '=', $tire->part_name)->first();
         if ($partFromDB == null)
             $tire->save();

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -439,126 +439,203 @@
                 <div class="modal-body"> <!-- Modal body for the input -->
                     <form action={{route('create.bike')}} method="POST">
                         @csrf
-                        <div class="form-group">
-                            <label for="type">Type</label>
-                            <select id="type" name="type" class="form-control" required>
-                                <option value="Mountain">Mountain</option>
-                                <option value="Racing">Racing</option>
-                                <option value="Recreational">Recreational</option>
-                            </select>
+                        <div class="modal-split">
+                            <div class="form-group">
+                                <label for="type">Type</label>
+                                <select id="type" name="type" class="form-control" required>
+                                    <option value="Mountain">Mountain</option>
+                                    <option value="Racing">Racing</option>
+                                    <option value="Recreational">Recreational</option>
+                                </select>
+                            </div>
+                            
+                            <div class="form-group">
+                                <label for="type">Price</label><br>
+                                <input id="price" name="price" class="form-control" required/>
+                            </div>
+                            <div class="form-group">
+                                <label for="size">Frame Size</label>
+                                <select id="size" name="size" class="form-control" required>
+                                    <option value="18">18"</option>
+                                    <option value="20">20"</option>
+                                    <option value="22">22"</option>
+                                    <option value="24">24"</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="color">Color</label>
+                                <select id="color" name="color" class="form-control" required>
+                                    <option value="Red">red</option>
+                                    <option value="Blue">blue</option>
+                                    <option value="Green">green</option>
+                                    <option value="Yellow">yellow</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="finish">Finishes</label>
+                                <select id="finish" name="finish" class="form-control" required>
+                                    <option value="Matt">Matt</option>
+                                    <option value="Chrome">Chrome</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="grade">Grade</label>
+                                <select id="grade" name="grade" class="form-control" required>
+                                    <option value="Aluminium">Aluminium</option>
+                                    <option value="Steel">Steel</option>
+                                    <option value="Carbon">Carbon</option>
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="quantity_in_stock">Quantity in Stock</label>
+                                <input id="quantity_in_stock" name="quantity_in_stock" class="form-control" type="text"
+                                    required>
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="fork">Fork</label>
-                            <select id="fork" name="fork" class="form-control" required>
-                                <option value="CarbonFiber">Carbon Fiber</option>
-                                <option value="Titanium">Titanium</option>
-                                <option value="Magnesium">Magnesium</option>
-                            </select>
+                        <div class="modal-split">
+                            <div class="form-group">
+                                <label for="fork">Fork</label>
+                                <select id="fork" class="form-control" name="fork" required>
+                                    <option value="">-- SELECT FORK --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Fork")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="seatpost">SeatPost</label><br>
+                                <select id="seatpost" class="form-control" name="seatpost" required>
+                                <option value="">-- SELECT SEATPOST --</option>
+                                @foreach($parts as $part)
+                                    @if($part->category == "Seatpost")
+                                        <option value={{$part->id}}>{{$part->part_name}}</option>
+                                    @endif
+                                @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="headset">Headset</label>
+                                <select id="headset" class="form-control" name="headset" required>
+                                    <option value="">-- SELECT HEADSET --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Headset")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="cranks">cranks</label>
+                                <select id="cranks" class="form-control" name="cranks" required>
+                                    <option value="">-- SELECT CRANKSET --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Crankset")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="pedals">Pedals</label>
+                                <select id="pedals" class="form-control" name="pedals" required>
+                                    <option value="">-- SELECT PEDALS --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Pedals")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+
+                            </div>
+                            <div class="form-group">
+                                <label for="handlebar">Handlebar</label><br>
+                                <select id="handlebar" class="form-control" name="handlebar" required>
+                                    <option value="">-- SELECT HANDLEBAR --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Handlebar")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+                            
+                            </div>
+                            <div class="form-group">
+                                <label for="stem">Stem</label><br>
+                                <select id="stem" class="form-control" name="stem" required>
+                                    <option value="">-- SELECT STEM --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Stem")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                
+                                <label for="saddle">Saddle</label><br>
+                                <select id="saddle" class="form-control" name="saddle" required>
+                                    <option value="">-- SELECT SADDLE --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Saddle")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+
+                            </div>
+                            <div class="form-group">
+                                <label for="brakes">Brakes</label><br>
+                                <select id="brakes" class="form-control" name="brakes" required>
+                                    <option value="">-- SELECT BRAKES --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Brakes")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+
+                            </div>
+                            <div class="form-group">
+                                <label for="shock">Shock</label><br>
+                                <select id="shock" class="form-control" name="shock" required>
+                                    <option>-- SELECT SHOCK --</option>
+                                    @foreach($parts as $part)
+                                        @if($part->category == "Shock")
+                                            <option value={{$part->id}}>{{$part->part_name}}</option>
+                                        @endif
+                                    @endforeach
+                                </select>
+
+                            </div>
+                            <div class="form-group">
+                                <label for="rim">Rim</label><br>
+                                <select id="rim" class="form-control" name="rim" required>
+                                <option value="">-- SELECT RIM --</option>
+                                @foreach($parts as $part)
+                                    @if($part->category == "Rim")
+                                        <option value={{$part->id}}>{{$part->part_name}}</option>
+                                    @endif
+                                @endforeach
+                                </select>
+                            </div>
+                            <div class="form-group">
+                                <label for="tire">Tire</label><br>
+                                <select id="tire" class="form-control" name="tire" required>
+                                <option value="">-- SELECT TIRE --</option>
+                                @foreach($parts as $part)
+                                    @if($part->category == "Tire")
+                                        <option value={{$part->id}}>{{$part->part_name}}</option>
+                                    @endif
+                                @endforeach
+                                </select>
+                            </div>
                         </div>
-                        <div class="form-group">
-                            <label for="seatpost">Seatpost</label><br>
-                            <input type="text" id="seatpost" name="seatpost" class="form-control" value="Seatpost" readonly>
+                        <div class="modal-footer">
+                               
                         </div>
-                        <div class="form-group">
-                            <label for="headset">Headset</label>
-                            <select id="headset" name="headset" class="form-control" required>
-                                <option value="threaded">threaded</option>
-                                <option value="threadless">Threadless</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="cranks">cranks</label>
-                            <select id="cranks" name="cranks" class="form-control" required>
-                                <option value="aluminum">aluminum</option>
-                                <option value="titanium">Titanium</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="pedals">Pedals</label>
-                            <select id="pedals" name="pedals" class="form-control" required>
-                                <option value="polycarbonate">Polycarbonate (1 pair)</option>
-                                <option value="metal">metal (1 pair)</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="handlebar">handlebar</label><br>
-                            <input type="text" id="handlebar" name="handlebar" class="form-control" value="Standard" readonly>
-                        </div>
-                        <div class="form-group">
-                            <label for="stem">stem</label><br>
-                            <input type="text" id="stem" name="stem" class="form-control" value="Stem" readonly>
-                        </div>
-                        <div class="form-group">
-                            <label for="saddle">Saddle</label>
-                            <select id="saddle" name="saddle" class="form-control" required>
-                                <option value="Plastic">Plastic</option>
-                                <option value="carbonfiber">Carbon Fiber Saddle</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="brakes">Brakes</label>
-                            <select id="brakes" name="brakes" class="form-control" required>
-                                <option value="rim">Rim Assembly</option>
-                                <option value="disk">Disk Assembly</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="shock">shock</label><br>
-                            <input type="text" id="shock" name="shock" class="form-control" value="shock" readonly>
-                        </div>
-                        <div class="form-group">
-                            <label for="rim">rim</label><br>
-                            <input type="text" id="rim" name="rim" class="form-control" value="rim" readonly>
-                        </div>
-                        <div class="form-group">
-                            <label for="tire">tire</label><br>
-                            <input type="text" id="tire" name="tire" class="form-control" value="tire" readonly>
-                        </div>
-                        <div class="form-group">
-                            <label for="type">Price</label><br>
-                            <input id="price" name="price" class="form-control" required/>
-                        </div>
-                        <div class="form-group">
-                            <label for="size">Frame Size</label>
-                            <select id="size" name="size" class="form-control" required>
-                                <option value="18">18"</option>
-                                <option value="20">20"</option>
-                                <option value="22">22"</option>
-                                <option value="24">24"</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="color">Color</label>
-                            <select id="color" name="color" class="form-control" required>
-                                <option value="Red">red</option>
-                                <option value="Blue">blue</option>
-                                <option value="Green">green</option>
-                                <option value="Yellow">yellow</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="finish">Finishes</label>
-                            <select id="finish" name="finish" class="form-control" required>
-                                <option value="Matt">Matt</option>
-                                <option value="Chrome">Chrome</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="grade">Grade</label>
-                            <select id="grade" name="grade" class="form-control" required>
-                                <option value="Aluminium">Aluminium</option>
-                                <option value="Steel">Steel</option>
-                                <option value="Carbon">Carbon</option>
-                            </select>
-                        </div>
-                        <div class="form-group">
-                            <label for="quantity_in_stock">Quantity in Stock</label>
-                            <input id="quantity_in_stock" name="quantity_in_stock" class="form-control" type="text"
-                                   required>
-                        </div>
-                </div>
-                <div class="modal-footer">
-                    <input type="submit" class="btn btn-primary" value="create bike">
+                        
                 </div>
                 </form>
             </div>
@@ -658,6 +735,96 @@
                 form.append(cloned_input)
 
 
+            }
+
+            $(document).ready(function() {
+                prep_modal();
+            });
+
+            function prep_modal()
+            {
+            $(".modal").each(function() {
+
+            var element = this;
+                var pages = $(this).find('.modal-split');
+
+            if (pages.length != 0)
+            {
+                    pages.hide();
+                    pages.eq(0).show();
+
+                    var b_button = document.createElement("button");
+                            b_button.setAttribute("type","button");
+                                b_button.setAttribute("class","btn btn-primary");
+                                b_button.setAttribute("style","display: none;");
+                                b_button.innerHTML = "Back";
+
+                    var n_button = document.createElement("button");
+                            n_button.setAttribute("type","button");
+                                n_button.setAttribute("class","btn btn-primary");
+                                n_button.innerHTML = "Next";
+
+                    $(this).find('.modal-footer').append(b_button).append(n_button);
+
+
+                    var page_track = 0;
+
+                    $(n_button).click(function() {
+                    
+                    this.blur();
+
+                        if(page_track == 0)
+                        {
+                            $(b_button).show();
+                        }
+
+                        if(page_track == pages.length-2)
+                        {
+                            $(n_button).text("Create Bike");  
+                        }
+
+                    if(page_track == pages.length-1)
+                    {
+                    $(element).find("form").submit();
+                    }
+
+                        if(page_track < pages.length-1)
+                        {
+                            page_track++;
+
+                            pages.hide();
+                            pages.eq(page_track).show();
+                        }
+
+
+                    });
+
+                    $(b_button).click(function() {
+
+                        if(page_track == 1)
+                        {
+                            $(b_button).hide();
+                        }
+
+                        if(page_track == pages.length-1)
+                        {
+                            $(n_button).text("Next");
+                        }
+
+                        if(page_track > 0)
+                        {
+                            page_track--;
+
+                            pages.hide();
+                            pages.eq(page_track).show();
+                        }
+
+
+                    });
+
+            }
+
+            });
             }
 
         </script>

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -68,6 +68,9 @@
                                         <td style="background-color:#FF0000">Low</td>
                                     @endif
                                     <td>
+                                        <a type="button" class="btn btn-success"
+                                            data-target="#modal-show-parts{{ $bike->id }}" data-toggle="modal"
+                                            id="modal-show-parts">Show Parts</a>
                                         <a class="btn btn-primary" data-placement="top"
                                            data-target="#modal-edit-bike{{ $bike->id }}" data-toggle="modal"
                                            id="modal-edit-bike">Edit</a>
@@ -161,6 +164,160 @@
                                             </div>
                                         </div>
                                     </div>
+                                </div>
+
+                                <div class="modal fade" id="modal-show-parts{{ $bike->id }}" tabindex="-1" role="dialog"
+                                     aria-labelledby="show_parts_modal_label" aria-hidden="true">
+                                    <div class="modal-dialog" role="document">
+                                        <div class="modal-content">
+                                            <div class="modal-header">
+                                                <h5 class="modal-title" id="show_parts_label">Showing Parts</h5>
+                                                <button type="button" class="close" data-dismiss="modal"
+                                                        aria-label="Close">
+                                                    <span aria-hidden="true">&times;</span>
+                                                </button>
+                                            </div>
+                                            <div class="modal-body"> <!-- Modal body for the input -->
+                                            <div class="form-group">
+                                                <label for="fork">Fork</label>
+                                                <input name="fork" id="fork" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Fork')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="seatpost">SeatPost</label><br>
+                                                <input name="seatpost" id="seatpost" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Seatpost')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="headset">Headset</label>
+                                                <input name="headset" id="headset" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Headset')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="cranks">Crankset</label>
+                                                <input name="cranks" id="cranks" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Crankset')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="pedals">Pedals</label>
+                                                <input name="pedals" id="pedals" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Pedals')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="handlebar">Handlebar</label><br>
+                                                <input name="handlebar" id="handlebar" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Handlebar')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="stem">Stem</label><br>
+                                                <input name="stem" id="stem" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Stem')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                
+                                                <label for="saddle">Saddle</label><br>
+                                                <input name="saddle" id="saddle" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Saddle')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="brakes">Brakes</label><br>
+                                                <input name="brakes" id="brakes" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Brakes')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="shock">Shock</label><br>
+                                                <input name="shock" id="shock" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Shock')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="rim">Rim</label><br>
+                                                <input name="rim" id="rim" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Rim')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            <div class="form-group">
+                                                <label for="tire">Tire</label><br>
+                                                <input name="tire" id="tire" type="text" class="form-control" 
+                                                    value ="{{ DB::table('bike_part')
+                                                        ->join('parts', 'bike_part.part_id', '=', 'parts.id')
+                                                        ->where('bike_id', '=', $bike->id)
+                                                        ->where('category', '=', 'Tire')
+                                                        ->value('part_name')}}"
+                                                        readonly>
+                                                </input>
+                                            </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
 
                             @endforeach
                             </tbody>

--- a/ERP/resources/views/inventory.blade.php
+++ b/ERP/resources/views/inventory.blade.php
@@ -448,7 +448,74 @@
                             </select>
                         </div>
                         <div class="form-group">
-                            <label for="type">Price</label>
+                            <label for="fork">Fork</label>
+                            <select id="fork" name="fork" class="form-control" required>
+                                <option value="CarbonFiber">Carbon Fiber</option>
+                                <option value="Titanium">Titanium</option>
+                                <option value="Magnesium">Magnesium</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="seatpost">Seatpost</label><br>
+                            <input type="text" id="seatpost" name="seatpost" class="form-control" value="Seatpost" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="headset">Headset</label>
+                            <select id="headset" name="headset" class="form-control" required>
+                                <option value="threaded">threaded</option>
+                                <option value="threadless">Threadless</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="cranks">cranks</label>
+                            <select id="cranks" name="cranks" class="form-control" required>
+                                <option value="aluminum">aluminum</option>
+                                <option value="titanium">Titanium</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="pedals">Pedals</label>
+                            <select id="pedals" name="pedals" class="form-control" required>
+                                <option value="polycarbonate">Polycarbonate (1 pair)</option>
+                                <option value="metal">metal (1 pair)</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="handlebar">handlebar</label><br>
+                            <input type="text" id="handlebar" name="handlebar" class="form-control" value="Standard" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="stem">stem</label><br>
+                            <input type="text" id="stem" name="stem" class="form-control" value="Stem" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="saddle">Saddle</label>
+                            <select id="saddle" name="saddle" class="form-control" required>
+                                <option value="Plastic">Plastic</option>
+                                <option value="carbonfiber">Carbon Fiber Saddle</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="brakes">Brakes</label>
+                            <select id="brakes" name="brakes" class="form-control" required>
+                                <option value="rim">Rim Assembly</option>
+                                <option value="disk">Disk Assembly</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="shock">shock</label><br>
+                            <input type="text" id="shock" name="shock" class="form-control" value="shock" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="rim">rim</label><br>
+                            <input type="text" id="rim" name="rim" class="form-control" value="rim" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="tire">tire</label><br>
+                            <input type="text" id="tire" name="tire" class="form-control" value="tire" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="type">Price</label><br>
                             <input id="price" name="price" class="form-control" required/>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
When logging in as a product manager and proceeding to the Inventory page, you can now specify the particular parts required to build the new bicycle you wish to create.

- First click on "Add a new Bicycle" and fill in the bicycle information on the modal that pops up.

![Screenshot 2021-04-06 043054](https://user-images.githubusercontent.com/47061375/113682771-7f97a100-9691-11eb-9f1d-7d4bfda40100.png)

- Click "Next" and you will now be prompted to enter the required parts.

![Screenshot 2021-04-06 043109](https://user-images.githubusercontent.com/47061375/113682928-a6ee6e00-9691-11eb-90cd-f8ad833df3eb.png)

- Select the parts we have in stock for each category and click "Create Bike".

![Screenshot 2021-04-06 043159](https://user-images.githubusercontent.com/47061375/113683060-c5ed0000-9691-11eb-9efc-3ed2e9207df2.png)

- You will be returned to the Inventory page with the updated bicycle table.

![Screenshot 2021-04-06 043219](https://user-images.githubusercontent.com/47061375/113683164-e321ce80-9691-11eb-9c8f-fc642ac1aad4.png)

- Click on the "Show Parts" button to see the associated parts with each bike.

![Screenshot 2021-04-06 043245](https://user-images.githubusercontent.com/47061375/113683243-f765cb80-9691-11eb-9c1a-c7c9892a4ef9.png)


